### PR TITLE
feat(web-app): removes duplicate exit button from passkey modal

### DIFF
--- a/apps/web-app/pages/join/passkey.vue
+++ b/apps/web-app/pages/join/passkey.vue
@@ -291,12 +291,6 @@
       <template #header>
         <div class="flex items-center justify-between">
           <p>How to add a passkey?</p>
-          <UnUiButton
-            color="gray"
-            variant="ghost"
-            icon="i-ph-x"
-            class="-my-1"
-            @click="howToAddPasskeyDialogOpen = false" />
         </div>
       </template>
       <div class="w-full flex flex-col items-center gap-4">


### PR DESCRIPTION
## What does this PR do?
removes duplicate exit button from passkey modal
before:
<img width="611" alt="Screenshot 2024-01-24 at 22 32 18" src="https://github.com/uninbox/UnInbox/assets/60504110/2fa563cc-28a3-4745-8351-53eeb67a2ccd">

after:
<img width="619" alt="Screenshot 2024-01-24 at 22 32 28" src="https://github.com/uninbox/UnInbox/assets/60504110/af211d87-0d9c-4a54-81a1-1041673f46ae">


Fixes #36

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required
- [x] Read [Contributing Guide](./CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [x] Tested my code in a local environment
- [x] Commented on my code in hard-to-understand areas
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [x] If a UI change was made: Added a screen recording or screenshots to this PR
- [x] Updated the UnInbox Docs if changes were necessary
