### PR TITLE
chore: create security.txt

### DIFF
--- a/.well-known/security.txt
+++ b/.well-known/security.txt
@@ -1,0 +1,4 @@
+Contact: security@UnInbox.io
+Preferred-Languages: en
+Canonical: https://uninbox.com/.well-known/security.txt
+Policy: https://github.com/uninbox/UnInbox/security/policy

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,6 @@
 # Security
 
-Contact: security@UnInbox.io
+Contact: security@uninbox.com
 
 Based on [https://supabase.com/.well-known/security.txt](https://supabase.com/.well-known/security.txt)
 
@@ -22,7 +22,7 @@ If you discover a vulnerability, we would like to know about it so we can take s
 
 ## Please do the following:
 
-- E-mail your findings to [security@UnInbox.io](mailto:security@UnInbox.io) - **_PLEASE NOTE: THE TLD FOR THE DOMAIN IS .io AND NOT .com_**
+- E-mail your findings to [security@uninbox.com](mailto:security@uninbox.com)
 - Do not run automated scanners on our infrastructure or dashboard. If you wish to do this, contact us and we will set up a sandbox for you.
 - Do not take advantage of the vulnerability or problem you have discovered, for example by downloading more data than necessary to demonstrate the vulnerability or deleting or modifying other people's data,
 - Do not reveal the problem to others until it has been resolved,

--- a/apps/landing-page/public/.well.known/security.txt
+++ b/apps/landing-page/public/.well.known/security.txt
@@ -1,4 +1,4 @@
-Contact: security@UnInbox.io
+Contact: security@uninbox.com
 Preferred-Languages: en
 Canonical: https://uninbox.com/.well-known/security.txt
 Policy: https://github.com/uninbox/UnInbox/security/policy

--- a/apps/web-app/public/.well-known/security.txt
+++ b/apps/web-app/public/.well-known/security.txt
@@ -1,0 +1,4 @@
+Contact: security@uninbox.com
+Preferred-Languages: en
+Canonical: https://app.uninbox.com/.well-known/security.txt
+Policy: https://github.com/uninbox/UnInbox/security/policy


### PR DESCRIPTION
## What does this PR do?

Adding a security.txt file enables security researchers to quickly and easily see where they can submit security issues and know that they are being taken serious. From the proposal website:

"When security risks in web services are discovered by independent security researchers who understand the severity of the risk, they often lack the channels to disclose them properly. As a result, security issues may be left unreported. security.txt defines a standard to help organizations define the process for security researchers to disclose security vulnerabilities securely.”

See also https://securitytxt.org/